### PR TITLE
Serialize Principal

### DIFF
--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
@@ -90,7 +90,8 @@ public class HazelcastSession extends StandardSession implements DataSerializabl
         objectDataOutput.writeBoolean(isValid);
         objectDataOutput.writeLong(thisAccessedTime);
         objectDataOutput.writeObject(id);
-
+        objectDataOutput.writeObject(principal);
+        
         serializeMap(getAttributes(), objectDataOutput);
         serializeMap(notes, objectDataOutput);
     }
@@ -123,6 +124,7 @@ public class HazelcastSession extends StandardSession implements DataSerializabl
         this.isValid = objectDataInput.readBoolean();
         this.thisAccessedTime = objectDataInput.readLong();
         this.id = objectDataInput.readObject();
+        this.principal = objectDataInput.readObject();
 
         setAttributes(deserializeMap(objectDataInput, true));
 


### PR DESCRIPTION
Tomcat 8.5.11 would not accept the session as authorized on the failover node unless it has the Principal on it.