### PR TITLE
Update HazelcastSessionManager.java

### DIFF
--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -168,7 +168,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(getContext().getSessionTimeout());
+        session.setMaxInactiveInterval(getContext().getSessionTimeout() * DEFAULT_SESSION_TIMEOUT);
 
         String newSessionId = sessionId;
         if (newSessionId == null) {


### PR DESCRIPTION
Context timeout is in minutes while max inactive timeout is in seconds. Must thus multiply by 60