### PR TITLE
Fixes Inconsistent Session Timestamps when using non-sticky sessions (#48)

### DIFF
--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
@@ -64,6 +64,29 @@ public class HazelcastSession extends StandardSession implements DataSerializabl
         updateSession();
     }
 
+    @Override
+    public long getLastAccessedTime() {
+        refreshAccessTimestamps();
+        return super.getLastAccessedTime();
+    }
+
+    @Override
+    public boolean isValid() {
+        refreshAccessTimestamps();
+        return super.isValid();
+    }
+
+    private void refreshAccessTimestamps() {
+        if (this.sessionManager != null && !this.sessionManager.isSticky()) {
+            HazelcastSession distributedSession = this.sessionManager.getDistributedMap().get(this.getId());
+            if (distributedSession != null) {
+                this.lastAccessedTime = distributedSession.lastAccessedTime;
+                this.maxInactiveInterval = distributedSession.maxInactiveInterval;
+                this.thisAccessedTime = distributedSession.thisAccessedTime;
+            }
+        }
+    }
+
     public boolean isDirty() {
         return dirty;
     }

--- a/tomcat-core/src/main/java/com/hazelcast/session/SessionManager.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/SessionManager.java
@@ -27,4 +27,9 @@ public interface SessionManager {
     IMap<String, HazelcastSession> getDistributedMap();
 
     boolean isDeferredEnabled();
+
+    /**
+     * @return true if this {@link SessionManager} has sticky sessions enabled, otherwise false.
+     */
+    boolean isSticky();
 }

--- a/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -341,6 +341,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         this.clientOnly = clientOnly;
     }
 
+    @Override
     public boolean isSticky() {
         return sticky;
     }

--- a/tomcat6/src/test/java/com/hazelcast/session/nonsticky/Tomcat6ClientServerNonStickySessionsTest.java
+++ b/tomcat6/src/test/java/com/hazelcast/session/nonsticky/Tomcat6ClientServerNonStickySessionsTest.java
@@ -1,11 +1,14 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.Tomcat6Configurator;
 import com.hazelcast.session.WebContainerConfigurator;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -14,5 +17,10 @@ public class Tomcat6ClientServerNonStickySessionsTest extends AbstractClientServ
     @Override
     protected WebContainerConfigurator<?> getWebContainerConfigurator() {
         return new Tomcat6Configurator();
+    }
+
+    @Override
+    public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
+        assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
     }
 }

--- a/tomcat6/src/test/java/com/hazelcast/session/nonsticky/Tomcat6P2PNonStickySessionsTest.java
+++ b/tomcat6/src/test/java/com/hazelcast/session/nonsticky/Tomcat6P2PNonStickySessionsTest.java
@@ -1,11 +1,14 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.Tomcat6Configurator;
 import com.hazelcast.session.WebContainerConfigurator;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -14,5 +17,10 @@ public class Tomcat6P2PNonStickySessionsTest extends AbstractP2PNonStickySession
     @Override
     protected WebContainerConfigurator<?> getWebContainerConfigurator() {
         return new Tomcat6Configurator();
+    }
+
+    @Override
+    public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
+        assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
     }
 }

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -346,6 +346,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         this.clientOnly = clientOnly;
     }
 
+    @Override
     public boolean isSticky() {
         return sticky;
     }

--- a/tomcat7/src/test/java/com/hazelcast/session/nonsticky/Tomcat7ClientServerNonStickySessionsTest.java
+++ b/tomcat7/src/test/java/com/hazelcast/session/nonsticky/Tomcat7ClientServerNonStickySessionsTest.java
@@ -21,7 +21,7 @@ public class Tomcat7ClientServerNonStickySessionsTest extends AbstractClientServ
 
     @Override
     public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
-        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
         assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
     }
 }

--- a/tomcat7/src/test/java/com/hazelcast/session/nonsticky/Tomcat7ClientServerNonStickySessionsTest.java
+++ b/tomcat7/src/test/java/com/hazelcast/session/nonsticky/Tomcat7ClientServerNonStickySessionsTest.java
@@ -1,11 +1,14 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.Tomcat7Configurator;
 import com.hazelcast.session.WebContainerConfigurator;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -14,5 +17,11 @@ public class Tomcat7ClientServerNonStickySessionsTest extends AbstractClientServ
     @Override
     protected WebContainerConfigurator<?> getWebContainerConfigurator() {
         return new Tomcat7Configurator();
+    }
+
+    @Override
+    public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
+        assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
     }
 }

--- a/tomcat7/src/test/java/com/hazelcast/session/nonsticky/Tomcat7P2PNonStickySessionsTest.java
+++ b/tomcat7/src/test/java/com/hazelcast/session/nonsticky/Tomcat7P2PNonStickySessionsTest.java
@@ -1,11 +1,14 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.Tomcat7Configurator;
 import com.hazelcast.session.WebContainerConfigurator;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -14,5 +17,11 @@ public class Tomcat7P2PNonStickySessionsTest extends AbstractP2PNonStickySession
     @Override
     protected WebContainerConfigurator<?> getWebContainerConfigurator() {
         return new Tomcat7Configurator();
+    }
+
+    @Override
+    public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
+        assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
     }
 }

--- a/tomcat7/src/test/java/com/hazelcast/session/nonsticky/Tomcat7P2PNonStickySessionsTest.java
+++ b/tomcat7/src/test/java/com/hazelcast/session/nonsticky/Tomcat7P2PNonStickySessionsTest.java
@@ -21,7 +21,7 @@ public class Tomcat7P2PNonStickySessionsTest extends AbstractP2PNonStickySession
 
     @Override
     public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
-        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
         assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
     }
 }

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -343,6 +343,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         this.clientOnly = clientOnly;
     }
 
+    @Override
     public boolean isSticky() {
         return sticky;
     }

--- a/tomcat8/src/test/java/com/hazelcast/session/nonsticky/Tomcat8ClientServerNonStickySessionsTest.java
+++ b/tomcat8/src/test/java/com/hazelcast/session/nonsticky/Tomcat8ClientServerNonStickySessionsTest.java
@@ -26,7 +26,7 @@ public class Tomcat8ClientServerNonStickySessionsTest extends AbstractClientServ
 
     @Override
     public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
-        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
         assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
     }
 }

--- a/tomcat8/src/test/java/com/hazelcast/session/nonsticky/Tomcat8ClientServerNonStickySessionsTest.java
+++ b/tomcat8/src/test/java/com/hazelcast/session/nonsticky/Tomcat8ClientServerNonStickySessionsTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.Java6ExcludeRule;
 import com.hazelcast.session.Tomcat8Configurator;
 import com.hazelcast.session.WebContainerConfigurator;
@@ -8,6 +9,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -19,5 +22,11 @@ public class Tomcat8ClientServerNonStickySessionsTest extends AbstractClientServ
     @Override
     protected WebContainerConfigurator<?> getWebContainerConfigurator() {
         return new Tomcat8Configurator();
+    }
+
+    @Override
+    public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
+        assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
     }
 }

--- a/tomcat8/src/test/java/com/hazelcast/session/nonsticky/Tomcat8P2PNonStickySessionsTest.java
+++ b/tomcat8/src/test/java/com/hazelcast/session/nonsticky/Tomcat8P2PNonStickySessionsTest.java
@@ -26,7 +26,7 @@ public class Tomcat8P2PNonStickySessionsTest extends AbstractP2PNonStickySession
 
     @Override
     public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
-        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
         assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
     }
 }

--- a/tomcat8/src/test/java/com/hazelcast/session/nonsticky/Tomcat8P2PNonStickySessionsTest.java
+++ b/tomcat8/src/test/java/com/hazelcast/session/nonsticky/Tomcat8P2PNonStickySessionsTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.Java6ExcludeRule;
 import com.hazelcast.session.Tomcat8Configurator;
 import com.hazelcast.session.WebContainerConfigurator;
@@ -8,6 +9,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -19,5 +22,11 @@ public class Tomcat8P2PNonStickySessionsTest extends AbstractP2PNonStickySession
     @Override
     protected WebContainerConfigurator<?> getWebContainerConfigurator() {
         return new Tomcat8Configurator();
+    }
+
+    @Override
+    public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
+        assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
     }
 }

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -329,6 +329,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         this.clientOnly = clientOnly;
     }
 
+    @Override
     public boolean isSticky() {
         return sticky;
     }

--- a/tomcat85/src/test/java/com/hazelcast/session/nonsticky/Tomcat85ClientServerNonStickySessionsTest.java
+++ b/tomcat85/src/test/java/com/hazelcast/session/nonsticky/Tomcat85ClientServerNonStickySessionsTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.Java6ExcludeRule;
 import com.hazelcast.session.Tomcat85Configurator;
 import com.hazelcast.session.WebContainerConfigurator;
@@ -8,6 +9,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -19,5 +22,11 @@ public class Tomcat85ClientServerNonStickySessionsTest extends AbstractClientSer
     @Override
     protected WebContainerConfigurator<?> getWebContainerConfigurator() {
         return new Tomcat85Configurator();
+    }
+
+    @Override
+    public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
+        assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
     }
 }

--- a/tomcat85/src/test/java/com/hazelcast/session/nonsticky/Tomcat85ClientServerNonStickySessionsTest.java
+++ b/tomcat85/src/test/java/com/hazelcast/session/nonsticky/Tomcat85ClientServerNonStickySessionsTest.java
@@ -26,7 +26,7 @@ public class Tomcat85ClientServerNonStickySessionsTest extends AbstractClientSer
 
     @Override
     public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
-        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
         assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
     }
 }

--- a/tomcat85/src/test/java/com/hazelcast/session/nonsticky/Tomcat85P2PNonStickySessionsTest.java
+++ b/tomcat85/src/test/java/com/hazelcast/session/nonsticky/Tomcat85P2PNonStickySessionsTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.Java6ExcludeRule;
 import com.hazelcast.session.Tomcat85Configurator;
 import com.hazelcast.session.WebContainerConfigurator;
@@ -8,6 +9,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -19,5 +22,11 @@ public class Tomcat85P2PNonStickySessionsTest extends AbstractP2PNonStickySessio
     @Override
     protected WebContainerConfigurator<?> getWebContainerConfigurator() {
         return new Tomcat85Configurator();
+    }
+
+    @Override
+    public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
+        assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
     }
 }

--- a/tomcat85/src/test/java/com/hazelcast/session/nonsticky/Tomcat85P2PNonStickySessionsTest.java
+++ b/tomcat85/src/test/java/com/hazelcast/session/nonsticky/Tomcat85P2PNonStickySessionsTest.java
@@ -26,7 +26,7 @@ public class Tomcat85P2PNonStickySessionsTest extends AbstractP2PNonStickySessio
 
     @Override
     public void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2) {
-        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
         assertEquals("Session lastAccessTime should be equal", session1.getLastAccessedTime(), session2.getLastAccessedTime());
+        assertEquals("Session thisAccessedTime should be equal", session1.getThisAccessedTime(), session2.getThisAccessedTime());
     }
 }


### PR DESCRIPTION
* If non-sticky sessions are configured, then refresh current object timestamps from the distributed session map.
* Adds tests to verify timestamps for non-sticky sessions.