### PR TITLE
WIP: Use the correct `ClassLoader` for the P2P solution

### DIFF
--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
@@ -138,6 +138,7 @@ public class HazelcastSession extends StandardSession implements DataSerializabl
     }
 
     private Map deserializeMap(ObjectDataInput objectDataInput, boolean concurrent) throws IOException {
+        LOG.info("ANTON - deserializing map with class loader: " + Thread.currentThread().getContextClassLoader());
         int mapSize = objectDataInput.readInt();
         Map map = concurrent ? new ConcurrentHashMap() : MapUtil.createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -105,7 +105,16 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         } else if (getHazelcastInstanceName() != null) {
             instance = Hazelcast.getHazelcastInstanceByName(getHazelcastInstanceName());
         } else {
-            instance = Hazelcast.getOrCreateHazelcastInstance(P2PLifecycleListener.getConfig());
+            ClassLoader classLoader = getContext().getLoader().getClassLoader();
+
+            log.info("ANTON - using P2P");
+            log.info("ANTON - context: " + getContext());
+            log.info("ANTON - contextPath: " + getContext().getServletContext().getContextPath());
+            log.info("ANTON - classLoader: " + classLoader);
+
+            Config config = P2PLifecycleListener.getConfig();
+            config.setClassLoader(classLoader);
+            instance = Hazelcast.getOrCreateHazelcastInstance(config);
         }
         if (getMapName() == null || "default".equals(getMapName())) {
             Context ctx = getContext();


### PR DESCRIPTION
Closes #55 

Ignore the temporary logging statements for now.

This solution works, however I'm still getting the exceptions. It looks like it tries with the "normal" class loader first, then uses the `WebAppClassLoader`.

Any ideas?

```
17-Jan-2019 14:53:24.731 INFO [http-apr-8080-exec-1] com.hazelcast.session.HazelcastSession.deserializeMap ANTON - deserializing map with class loader: java.net.URLClassLoader@23fc625e
17-Jan-2019 14:53:24.756 INFO [http-apr-8080-exec-1] com.hazelcast.session.HazelcastSession.deserializeMap ANTON - deserializing map with class loader: WebappClassLoader
  context: ROOT
  delegate: false
----------> Parent Classloader:
java.net.URLClassLoader@23fc625e
```