### PR TITLE
Fix for context classloader issue

### DIFF
--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastInstanceFactory.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastInstanceFactory.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ */
+
 package com.hazelcast.session;
 
 import com.hazelcast.client.HazelcastClient;
@@ -12,8 +16,11 @@ import org.apache.juli.logging.LogFactory;
 /**
  * Factory for {@link HazelcastInstance}'s for session management
  */
-public class HazelcastInstanceFactory {
-    private static final Log log = LogFactory.getLog(HazelcastInstanceFactory.class);
+public final class HazelcastInstanceFactory {
+    private static final Log LOGGER = LogFactory.getLog(HazelcastInstanceFactory.class);
+
+    private HazelcastInstanceFactory() {
+    }
 
     /**
      * Gets a {@link HazelcastInstance} by creating a new one (or getting the existing one on P2P setup).
@@ -33,7 +40,7 @@ public class HazelcastInstanceFactory {
                 clientConfig.setClassLoader(classLoader);
                 instance = HazelcastClient.newHazelcastClient(clientConfig);
             } catch (Exception e) {
-                log.error("Hazelcast Client could not be created.", e);
+                LOGGER.error("Hazelcast Client could not be created.", e);
                 throw new LifecycleException(e.getMessage());
             }
         } else if (instanceName != null) {

--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastInstanceFactory.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastInstanceFactory.java
@@ -1,0 +1,53 @@
+package com.hazelcast.session;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import org.apache.catalina.LifecycleException;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
+/**
+ * Factory for {@link HazelcastInstance}'s for session management
+ */
+public class HazelcastInstanceFactory {
+    private static final Log log = LogFactory.getLog(HazelcastInstanceFactory.class);
+
+    /**
+     * Gets a {@link HazelcastInstance} by creating a new one (or getting the existing one on P2P setup).
+     *
+     * @param classLoader the classloader to set for the {@link HazelcastInstance}
+     * @param clientOnly states if the instance is a client or not
+     * @param instanceName name of the Hazelcast instance
+     * @return the Hazelcast instance created/found
+     * @throws LifecycleException when {@link HazelcastInstance} cannot be created in client/server mode
+     */
+    public static HazelcastInstance getHazelcastInstance(ClassLoader classLoader, boolean clientOnly, String instanceName)
+            throws LifecycleException {
+        HazelcastInstance instance;
+        if (clientOnly) {
+            try {
+                ClientConfig clientConfig = ClientServerLifecycleListener.getConfig();
+                clientConfig.setClassLoader(classLoader);
+                instance = HazelcastClient.newHazelcastClient(clientConfig);
+            } catch (Exception e) {
+                log.error("Hazelcast Client could not be created.", e);
+                throw new LifecycleException(e.getMessage());
+            }
+        } else if (instanceName != null) {
+            instance = Hazelcast.getHazelcastInstanceByName(instanceName);
+        } else {
+            /*
+             Note that Hazelcast instance can only set a classloader during the initialization. If the context classloader
+             changes after the initialization of the Hazelcast instance, it cannot be changed for the Hazelcast instance.
+             */
+            Config config = P2PLifecycleListener.getConfig();
+            config.setClassLoader(classLoader);
+            instance = Hazelcast.getOrCreateHazelcastInstance(config);
+        }
+
+        return instance;
+    }
+}

--- a/tomcat-core/src/main/java/com/hazelcast/session/P2PLifecycleListener.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/P2PLifecycleListener.java
@@ -37,7 +37,6 @@ public class P2PLifecycleListener implements LifecycleListener {
             if (config.getInstanceName() == null) {
                 config.setInstanceName(SessionManager.DEFAULT_INSTANCE_NAME);
             }
-            Hazelcast.getOrCreateHazelcastInstance(config);
         } else if ("stop".equals(event.getType()) && !"false".equals(shutdown)) {
             HazelcastInstance instance = Hazelcast.getHazelcastInstanceByName(SessionManager.DEFAULT_INSTANCE_NAME);
             if (instance != null) {

--- a/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -4,11 +4,8 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
@@ -108,20 +105,9 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
         configureValves();
 
-        if (isClientOnly()) {
-            try {
-                ClientConfig clientConfig = ClientServerLifecycleListener.getConfig();
-                clientConfig.setClassLoader(getContainer().getLoader().getClassLoader());
-                instance = HazelcastClient.newHazelcastClient(clientConfig);
-            } catch (Exception e) {
-                log.error("Hazelcast Client could not be created.", e);
-                throw new LifecycleException(e.getMessage());
-            }
-        } else if (getHazelcastInstanceName() != null) {
-            instance = Hazelcast.getHazelcastInstanceByName(getHazelcastInstanceName());
-        } else {
-            instance = Hazelcast.getOrCreateHazelcastInstance(P2PLifecycleListener.getConfig());
-        }
+        instance = HazelcastInstanceFactory.
+                getHazelcastInstance(getContainer().getLoader().getClassLoader(), isClientOnly(), getHazelcastInstanceName());
+
         if (getMapName() == null || "default".equals(getMapName())) {
             Context ctx = (Context) getContainer();
             String contextPath = ctx.getServletContext().getContextPath();

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -4,11 +4,8 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
@@ -95,20 +92,9 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
         configureValves();
 
-        if (isClientOnly()) {
-            try {
-                ClientConfig clientConfig = ClientServerLifecycleListener.getConfig();
-                clientConfig.setClassLoader(getContainer().getLoader().getClassLoader());
-                instance = HazelcastClient.newHazelcastClient(clientConfig);
-            } catch (Exception e) {
-                log.error("Hazelcast Client could not be created.", e);
-                throw new LifecycleException(e.getMessage());
-            }
-        } else if (getHazelcastInstanceName() != null) {
-            instance = Hazelcast.getHazelcastInstanceByName(getHazelcastInstanceName());
-        } else {
-            instance = Hazelcast.getOrCreateHazelcastInstance(P2PLifecycleListener.getConfig());
-        }
+        instance = HazelcastInstanceFactory.
+                getHazelcastInstance(getContainer().getLoader().getClassLoader(), isClientOnly(), getHazelcastInstanceName());
+
         if (getMapName() == null || "default".equals(getMapName())) {
             Context ctx = (Context) getContainer();
             String contextPath = ctx.getServletContext().getContextPath();

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -4,11 +4,8 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
@@ -93,20 +90,9 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
         configureValves();
 
-        if (isClientOnly()) {
-            try {
-                ClientConfig clientConfig = ClientServerLifecycleListener.getConfig();
-                clientConfig.setClassLoader(getContext().getLoader().getClassLoader());
-                instance = HazelcastClient.newHazelcastClient(clientConfig);
-            } catch (Exception e) {
-                log.error("Hazelcast Client could not be created.", e);
-                throw new LifecycleException(e.getMessage());
-            }
-        } else if (getHazelcastInstanceName() != null) {
-            instance = Hazelcast.getHazelcastInstanceByName(getHazelcastInstanceName());
-        } else {
-            instance = Hazelcast.getOrCreateHazelcastInstance(P2PLifecycleListener.getConfig());
-        }
+        instance = HazelcastInstanceFactory.
+                getHazelcastInstance(getContext().getLoader().getClassLoader(), isClientOnly(), getHazelcastInstanceName());
+
         if (getMapName() == null || "default".equals(getMapName())) {
             Context ctx = getContext();
             String contextPath = ctx.getServletContext().getContextPath();

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -4,11 +4,8 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
@@ -76,20 +73,9 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
         configureValves();
 
-        if (isClientOnly()) {
-            try {
-                ClientConfig clientConfig = ClientServerLifecycleListener.getConfig();
-                clientConfig.setClassLoader(getContext().getLoader().getClassLoader());
-                instance = HazelcastClient.newHazelcastClient(clientConfig);
-            } catch (Exception e) {
-                log.error("Hazelcast Client could not be created.", e);
-                throw new LifecycleException(e.getMessage());
-            }
-        } else if (getHazelcastInstanceName() != null) {
-            instance = Hazelcast.getHazelcastInstanceByName(getHazelcastInstanceName());
-        } else {
-            instance = Hazelcast.getOrCreateHazelcastInstance(P2PLifecycleListener.getConfig());
-        }
+        instance = HazelcastInstanceFactory.
+                getHazelcastInstance(getContext().getLoader().getClassLoader(), isClientOnly(), getHazelcastInstanceName());
+
         if (getMapName() == null || "default".equals(getMapName())) {
             Context ctx = getContext();
             String contextPath = ctx.getServletContext().getContextPath();


### PR DESCRIPTION
Fixes #55.

This fix moves the initialization of the Hazelcast member instance on P2P mode to the startup of `HazelcastSessionManager` in order to access the context classloader. Please note that there might be still an issue if the context classloader changes dynamically, since Hazelcast doesn't allow to update the classloader after the initialization of the instance.