### PR TITLE
Changed copyright to 2019 and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ The following steps configure a sample P2P for Hazelcast Session Replication.
 
 Optionally, you can add a `configLocation` attribute into the `<Listener>` element. If not provided, `hazelcast.xml` in the classpath is used by default. URL or full filesystem path as a `configLocation` value is supported.
 
+***Classloader for Hazelcast Instance***
+
+Hazelcast instance sets and uses context classloader (`WebAppClassLoader`) whilst the initialization. However, Hazelcast's classloader configuration cannot be changed dynamically after the instance startup. Thus, if the context's classloader changes during the application runtime, it won't be reflected to the Hazelcast instance.  
+
 ## Deploying Client-Server for Tomcat
 
 In this deployment type, Tomcat instances work as clients on an existing Hazelcast Cluster.
@@ -165,7 +169,7 @@ An example client config that connects directly (i.e. doesn't use multicast) to 
 - Add `sticky` attribute into `<Manager>` element. Its default value is *true*.
 - Add `processExpiresFrequency` attribute into `<Manager>` element. It specifies the frequency of session validity check, in seconds. Its default value is *6* and the minimum value that you can set is *1*.
 - Add `deferredWrite` attribute into `<Manager>` element. Its default value is *true*.
-- In P2P mode, add `hazelcastInstanceName` attribute into `<Manager>` element. It specifies an existing Hazelcast instance to use for session replication.
+- In P2P mode, add `hazelcastInstanceName` attribute into `<Manager>` element. It specifies an existing Hazelcast instance to use for session replication. The same can be achieved by setting `instanceName` property in Hazelcast configuration. If no instance name is configured, Hazelcast instance starts with a default instance name (`SessionManager.DEFAULT_INSTANCE_NAME`).
 
 <br></br>
 

--- a/checkstyle/ClassHeader.txt
+++ b/checkstyle/ClassHeader.txt
@@ -1,4 +1,4 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tomcat-core/src/main/java/com/hazelcast/session/ClientServerLifecycleListener.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/ClientServerLifecycleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastInstanceFactory.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionChangeValve.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionChangeValve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionCommitValve.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionCommitValve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat-core/src/main/java/com/hazelcast/session/P2PLifecycleListener.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/P2PLifecycleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat-core/src/main/java/com/hazelcast/session/SessionManager.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat-core/src/main/java/com/hazelcast/session/package-info.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 /**

--- a/tomcat-core/src/test/resources/hazelcast-1.xml
+++ b/tomcat-core/src/test/resources/hazelcast-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tomcat-core/src/test/resources/hazelcast-2.xml
+++ b/tomcat-core/src/test/resources/hazelcast-2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tomcat-core/src/test/resources/hazelcast.xml
+++ b/tomcat-core/src/test/resources/hazelcast.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat6/src/main/java/com/hazelcast/session/package-info.java
+++ b/tomcat6/src/main/java/com/hazelcast/session/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 /**

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat7/src/main/java/com/hazelcast/session/package-info.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 /**

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat8/src/main/java/com/hazelcast/session/package-info.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 /**

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 package com.hazelcast.session;

--- a/tomcat85/src/main/java/com/hazelcast/session/package-info.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  */
 
 /**


### PR DESCRIPTION
The classheaders are updated to 2019. Also, readme is updated for classloader and instance name issues.