### PR TITLE
Updated the `findSession` method to fix concurrency issues

### DIFF
--- a/tomcat-core/src/main/java/com/hazelcast/session/LocalSessionsInvalidateListener.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/LocalSessionsInvalidateListener.java
@@ -1,0 +1,34 @@
+package com.hazelcast.session;
+
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
+import org.apache.catalina.Session;
+
+import java.util.Map;
+
+public class LocalSessionsInvalidateListener implements EntryEvictedListener<String, HazelcastSession>,
+        EntryRemovedListener<String, HazelcastSession> {
+
+    private Map<String, Session> sessions;
+
+    public LocalSessionsInvalidateListener(Map<String, Session> sessions) {
+        this.sessions = sessions;
+    }
+
+    @Override
+    public void entryEvicted(EntryEvent<String, HazelcastSession> event) {
+        invalidateSessions(event);
+    }
+
+    @Override
+    public void entryRemoved(EntryEvent<String, HazelcastSession> event) {
+        invalidateSessions(event);
+    }
+
+    private void invalidateSessions(EntryEvent<String, HazelcastSession> entryEvent) {
+        if (entryEvent.getMember() == null || !entryEvent.getMember().localMember()) {
+            sessions.remove(entryEvent.getKey());
+        }
+    }
+}

--- a/tomcat-core/src/main/java/com/hazelcast/session/LocalSessionsInvalidateListener.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/LocalSessionsInvalidateListener.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ */
+
 package com.hazelcast.session;
 
 import com.hazelcast.core.EntryEvent;

--- a/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -4,10 +4,8 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.map.listener.EntryRemovedListener;
 import org.apache.catalina.Context;
 import org.apache.catalina.Lifecycle;
 import org.apache.catalina.LifecycleException;
@@ -123,14 +121,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
 
         if (!isSticky()) {
-            sessionMap.addEntryListener(new EntryRemovedListener<String, HazelcastSession>() {
-                @Override
-                public void entryRemoved(EntryEvent<String, HazelcastSession> entryEvent) {
-                    if (entryEvent.getMember() == null || !entryEvent.getMember().localMember()) {
-                        sessions.remove(entryEvent.getKey());
-                    }
-                }
-            }, false);
+            sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);
         }
 
         log.info("HazelcastSessionManager started...");

--- a/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -5,10 +5,9 @@
 package com.hazelcast.session;
 
 import com.hazelcast.core.EntryEvent;
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.listener.EntryRemovedListener;
 import org.apache.catalina.Context;
 import org.apache.catalina.Lifecycle;
 import org.apache.catalina.LifecycleException;
@@ -124,27 +123,12 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
 
         if (!isSticky()) {
-            sessionMap.addEntryListener(new EntryListener<String, HazelcastSession>() {
-                public void entryAdded(EntryEvent<String, HazelcastSession> event) {
-                }
-
+            sessionMap.addEntryListener(new EntryRemovedListener<String, HazelcastSession>() {
+                @Override
                 public void entryRemoved(EntryEvent<String, HazelcastSession> entryEvent) {
                     if (entryEvent.getMember() == null || !entryEvent.getMember().localMember()) {
                         sessions.remove(entryEvent.getKey());
                     }
-                }
-
-                public void entryUpdated(EntryEvent<String, HazelcastSession> event) {
-                }
-
-                public void entryEvicted(EntryEvent<String, HazelcastSession> entryEvent) {
-                    entryRemoved(entryEvent);
-                }
-
-                public void mapEvicted(MapEvent event) {
-                }
-
-                public void mapCleared(MapEvent event) {
                 }
             }, false);
         }
@@ -238,8 +222,14 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             sessions.put(id, hazelcastSession);
 
             // call remove method to trigger eviction Listener on each node to invalidate local sessions
-            sessionMap.remove(id);
-            sessionMap.set(id, hazelcastSession);
+            // the call are performed in a pessimistic lock block to prevent concurrency problems whilst finding sessions
+            sessionMap.lock(id);
+            try {
+                sessionMap.remove(id);
+                sessionMap.set(id, hazelcastSession);
+            } finally {
+                sessionMap.unlock(id);
+            }
 
             return hazelcastSession;
 

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -4,10 +4,8 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.map.listener.EntryRemovedListener;
 import org.apache.catalina.Context;
 import org.apache.catalina.Lifecycle;
 import org.apache.catalina.LifecycleException;
@@ -110,14 +108,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
 
         if (!isSticky()) {
-            sessionMap.addEntryListener(new EntryRemovedListener<String, HazelcastSession>() {
-                @Override
-                public void entryRemoved(EntryEvent<String, HazelcastSession> entryEvent) {
-                    if (entryEvent.getMember() == null || !entryEvent.getMember().localMember()) {
-                        sessions.remove(entryEvent.getKey());
-                    }
-                }
-            }, false);
+            sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);
         }
 
         log.info("HazelcastSessionManager started...");

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -5,10 +5,9 @@
 package com.hazelcast.session;
 
 import com.hazelcast.core.EntryEvent;
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.listener.EntryRemovedListener;
 import org.apache.catalina.Context;
 import org.apache.catalina.Lifecycle;
 import org.apache.catalina.LifecycleException;
@@ -111,27 +110,12 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
 
         if (!isSticky()) {
-            sessionMap.addEntryListener(new EntryListener<String, HazelcastSession>() {
-                public void entryAdded(EntryEvent<String, HazelcastSession> event) {
-                }
-
+            sessionMap.addEntryListener(new EntryRemovedListener<String, HazelcastSession>() {
+                @Override
                 public void entryRemoved(EntryEvent<String, HazelcastSession> entryEvent) {
                     if (entryEvent.getMember() == null || !entryEvent.getMember().localMember()) {
                         sessions.remove(entryEvent.getKey());
                     }
-                }
-
-                public void entryUpdated(EntryEvent<String, HazelcastSession> event) {
-                }
-
-                public void entryEvicted(EntryEvent<String, HazelcastSession> entryEvent) {
-                    entryRemoved(entryEvent);
-                }
-
-                public void mapEvicted(MapEvent event) {
-                }
-
-                public void mapCleared(MapEvent event) {
                 }
             }, false);
         }
@@ -237,8 +221,14 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             sessions.put(id, hazelcastSession);
 
             // call remove method to trigger eviction Listener on each node to invalidate local sessions
-            sessionMap.remove(id);
-            sessionMap.set(id, hazelcastSession);
+            // the call are performed in a pessimistic lock block to prevent concurrency problems whilst finding sessions
+            sessionMap.lock(id);
+            try {
+                sessionMap.remove(id);
+                sessionMap.set(id, hazelcastSession);
+            } finally {
+                sessionMap.unlock(id);
+            }
 
             return hazelcastSession;
         } else {

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -4,10 +4,8 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.map.listener.EntryRemovedListener;
 import org.apache.catalina.Context;
 import org.apache.catalina.Lifecycle;
 import org.apache.catalina.LifecycleException;
@@ -108,14 +106,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
 
         if (!isSticky()) {
-            sessionMap.addEntryListener(new EntryRemovedListener<String, HazelcastSession>() {
-                @Override
-                public void entryRemoved(EntryEvent<String, HazelcastSession> entryEvent) {
-                    if (entryEvent.getMember() == null || !entryEvent.getMember().localMember()) {
-                        sessions.remove(entryEvent.getKey());
-                    }
-                }
-            }, false);
+            sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);
         }
 
         log.info("HazelcastSessionManager started...");

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -90,14 +90,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
 
         if (!isSticky()) {
-            sessionMap.addEntryListener(new EntryRemovedListener<String, HazelcastSession>() {
-                @Override
-                public void entryRemoved(EntryEvent<String, HazelcastSession> entryEvent) {
-                    if (entryEvent.getMember() == null || !entryEvent.getMember().localMember()) {
-                        sessions.remove(entryEvent.getKey());
-                    }
-                }
-            }, false);
+            sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);
         }
 
         log.info("HazelcastSessionManager started...");

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -5,10 +5,9 @@
 package com.hazelcast.session;
 
 import com.hazelcast.core.EntryEvent;
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.listener.EntryRemovedListener;
 import org.apache.catalina.Context;
 import org.apache.catalina.Lifecycle;
 import org.apache.catalina.LifecycleException;
@@ -91,27 +90,12 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
 
         if (!isSticky()) {
-            sessionMap.addEntryListener(new EntryListener<String, HazelcastSession>() {
-                public void entryAdded(EntryEvent<String, HazelcastSession> event) {
-                }
-
+            sessionMap.addEntryListener(new EntryRemovedListener<String, HazelcastSession>() {
+                @Override
                 public void entryRemoved(EntryEvent<String, HazelcastSession> entryEvent) {
                     if (entryEvent.getMember() == null || !entryEvent.getMember().localMember()) {
                         sessions.remove(entryEvent.getKey());
                     }
-                }
-
-                public void entryUpdated(EntryEvent<String, HazelcastSession> event) {
-                }
-
-                public void entryEvicted(EntryEvent<String, HazelcastSession> entryEvent) {
-                    entryRemoved(entryEvent);
-                }
-
-                public void mapEvicted(MapEvent event) {
-                }
-
-                public void mapCleared(MapEvent event) {
                 }
             }, false);
         }
@@ -220,8 +204,14 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             sessions.put(id, hazelcastSession);
 
             // call remove method to trigger eviction Listener on each node to invalidate local sessions
-            sessionMap.remove(id);
-            sessionMap.set(id, hazelcastSession);
+            // the call are performed in a pessimistic lock block to prevent concurrency problems whilst finding sessions
+            sessionMap.lock(id);
+            try {
+                sessionMap.remove(id);
+                sessionMap.set(id, hazelcastSession);
+            } finally {
+                sessionMap.unlock(id);
+            }
 
             return hazelcastSession;
         } else {

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -4,10 +4,8 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.map.listener.EntryRemovedListener;
 import org.apache.catalina.Context;
 import org.apache.catalina.Lifecycle;
 import org.apache.catalina.LifecycleException;


### PR DESCRIPTION
Fixes #42 & #34 

Hazelcast calls in `HazelcastSessionManager.findSession(id)` method (`remove` and `set`) should be concurrent in order to provide thread-safe access to the session object. 

The depreciated usage of `EntryListener` is also replaced with `MapListener`.