### PR TITLE
Changed the member instances to clients in two test cases

### DIFF
--- a/tomcat-core/src/test/java/com/hazelcast/session/nonsticky/AbstractNonStickySessionsTest.java
+++ b/tomcat-core/src/test/java/com/hazelcast/session/nonsticky/AbstractNonStickySessionsTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.session.nonsticky;
 
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.session.AbstractHazelcastSessionsTest;
@@ -84,7 +85,7 @@ public abstract class AbstractNonStickySessionsTest extends AbstractHazelcastSes
         value = executeRequest("invalidate", SERVER_PORT_2, cookieStore);
         assertEquals("true", value);
 
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = HazelcastClient.newHazelcastClient();
         IMap<Object, Object> map = instance.getMap("default");
         assertEquals(0, map.size());
     }

--- a/tomcat-core/src/test/java/com/hazelcast/session/sticky/AbstractStickySessionsTest.java
+++ b/tomcat-core/src/test/java/com/hazelcast/session/sticky/AbstractStickySessionsTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.session.sticky;
 
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -87,7 +88,7 @@ public abstract class AbstractStickySessionsTest extends AbstractHazelcastSessio
         value = executeRequest("invalidate", SERVER_PORT_1, cookieStore);
         assertEquals("true", value);
 
-        HazelcastInstance instance = createHazelcastInstance();
+        HazelcastInstance instance = HazelcastClient.newHazelcastClient();
         IMap<Object, Object> map = instance.getMap("default");
         assertEquals(0, map.size());
     }


### PR DESCRIPTION
The member instances are used to validate the session parameters that are kept in the cluster. They might not initialize, or join to the existing cluster because of the configuration. They are changed to client instances to overcome these issues.