### PR TITLE
Updated pom.xml dependencies for merging client & core modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
             <scope>provided</scope>
             <optional>true</optional>


### PR DESCRIPTION
Fixes compile and test errors occurring because of the merge of client and core modules in this https://github.com/hazelcast/hazelcast/pull/15366 for Hazelcast 4.0.