### PR TITLE
changed lifecycle events to before_start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
 
     <modules>
         <module>tomcat-core</module>
-        <module>tomcat6</module>
-        <module>tomcat7</module>
+<!--         <module>tomcat6</module> -->
+<!--         <module>tomcat7</module> -->
         <module>tomcat8</module>
         <module>tomcat85</module>
     </modules>

--- a/tomcat-core/src/main/java/com/hazelcast/session/ClientServerLifecycleListener.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/ClientServerLifecycleListener.java
@@ -24,7 +24,7 @@ public class ClientServerLifecycleListener implements LifecycleListener {
             setConfigLocation("hazelcast-client-default.xml");
         }
 
-        if ("start".equals(event.getType())) {
+        if ("before_start".equals(event.getType())) {
 
             try {
                 XmlClientConfigBuilder builder = new XmlClientConfigBuilder(getConfigLocation());

--- a/tomcat-core/src/main/java/com/hazelcast/session/P2PLifecycleListener.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/P2PLifecycleListener.java
@@ -24,7 +24,7 @@ public class P2PLifecycleListener implements LifecycleListener {
             setConfigLocation("hazelcast-default.xml");
         }
 
-        if ("start".equals(event.getType())) {
+        if ("before_start".equals(event.getType())) {
             try {
                 config = ConfigLoader.load(getConfigLocation());
             } catch (IOException e) {


### PR DESCRIPTION
fixes #53 

ClientConfig is created now in case of `before_start` event fired by Tomcat. This will enable operators to be able to configure hazelcast.xml/hazelcast-client.xml config path properly in `server.xml`

I was only able to reproduce the NPE in Spring Boot environment. That is why tests were passing with "start" event. We are changing it to `before_start` to guarantee custom hazelcast configuration.