### PR TITLE
fix(pom.xml): Remove deprecated maven dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
 
     <repositories>
         <repository>
+            <id>backup-repository</id>
+            <name>Maven Central (Backup)</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+        <repository>
             <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
 
     <repositories>
         <repository>
-            <id>backup-repository</id>
-            <name>Maven Central (Backup)</name>
-            <url>http://repo2.maven.org/maven2/</url>
-        </repository>
-        <repository>
             <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>


### PR DESCRIPTION
```
 👉 curl  http://repo2.maven.org/maven2/org/apache/tomcat/tomcat-servlet-api/8.0.36/tomcat-servlet-api-8.0.36.pom -v
*   Trying 92.242.140.2...
* TCP_NODELAY set
* Connected to repo2.maven.org (92.242.140.2) port 80 (#0)
> GET /maven2/org/apache/tomcat/tomcat-servlet-api/8.0.36/tomcat-servlet-api-8.0.36.pom HTTP/1.1
> Host: repo2.maven.org
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx
< Date: Tue, 14 Apr 2020 23:23:20 GMT
< Content-Type: text/html; charset=utf-8
< Transfer-Encoding: chunked
< Connection: close
< Expires: Tue, 14 Apr 2020 23:33:20 GMT
< Cache-Control: max-age=600
< X-Frame-Options: DENY
<
* Closing connection 0
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><meta http-equiv="refresh" content="0;url=http://finder.cox.net/main?ParticipantID=96e687opkbv4scrood8k84drs6gw5duf&FailedURI=http%3A%2F%2Frepo2.maven.org%2Fmaven2%2Forg%2Fapache%2Ftomcat%2Ftomcat-servlet-api%2F8.0.36%2Ftomcat-servlet-api-8.0.36.pom&FailureMode=1&Implementation=&AddInType=4&Version=pywr1.0&ClientLocation=us"/><script type="text/javascript">url="http://finder.cox.net/main?ParticipantID=96e687opkbv4scrood8k84drs6gw5duf&FailedURI=http%3A%2F%2Frepo2.maven.org%2Fmaven2%2Forg%2Fapache%2Ftomcat%2Ftomcat-servlet-api%2F8.0.36%2Ftomcat-servlet-api-8.0.36.pom&FailureMode=1&Implementation=&AddInType=4&Version=pywr1.0&ClientLocation=us";if(top.location!=location){var w=window,d=document,e=d.documentElement,b=d.body,x=w.innerWidth||e.clientWidth||b.clientWidth,y=w.innerHeight||e.clientHeight||b.clientHeight;url+="&w="+x+"&h="+y;}window.location.replace(url);</script></head><body></body></html>%
```