### PR TITLE
Separated Hazelcast's own session expiration from Tomcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,7 @@ Based on Tomcat configuration or `sessionTimeout` setting in `web.xml`, sessions
 
 `processExpiresFrequency`, which is defined in [`<Manager>`](#configuring-manager-element-for-tomcat), is the only setting that controls the behavior of session expiry policy in the Tomcat Web Session Replication Module. By setting this, you can set the frequency of the session expiration checks in the Tomcat Instance.
 
-Starting with v2.1, the session expiration in Hazelcast cluster is separated from the Tomcat control. Instead, Hazelcast's own expiry mechanism (`max-idle-seconds` property) is used. By default, `sessionTimeout` value is configured as the `max-idle-seconds` for the session map in Hazelcast. So, the session expiry in Hazelcast cluster happens at the same time with Tomcat by default. However, if you would like to change the expiration setting on the Hazelcast cluster, you need to configure eviction for the related session map. Please see the Hazelcast's own eviction mechanism details [here](https://docs.hazelcast.org/docs/latest/manual/html-single/#map-eviction).
-Please note that if you change the Hazelcast's eviction configuration, the sessions might be kept alive longer than the `sessionTimeout` setting.         
+Starting with v2.1, the session expiration in Hazelcast cluster is not controlled by Tomcat anymore. **Instead, Hazelcast's own expiry/eviction mechanism should be configured.** In order to to configure the expiration settings on the Hazelcast cluster, you need to configure eviction for the related session map. Please see the Hazelcast's own eviction mechanism details [here](https://docs.hazelcast.org/docs/latest/manual/html-single/#map-eviction). Please note that the sessions might be kept alive longer than the `sessionTimeout` setting in the cluster if you don't configure the Hazelcast expiration/eviction properly.         
 
 # Enabling Session Replication in Multi-App Environments
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ Based on Tomcat configuration or `sessionTimeout` setting in `web.xml`, sessions
 
 `processExpiresFrequency`, which is defined in [`<Manager>`](#configuring-manager-element-for-tomcat), is the only setting that controls the behavior of session expiry policy in the Tomcat Web Session Replication Module. By setting this, you can set the frequency of the session expiration checks in the Tomcat Instance.
 
+Starting with v2.1, the session expiration in Hazelcast cluster is separated from the Tomcat control. Instead, Hazelcast's own expiry mechanism (`max-idle-seconds` property) is used. By default, `sessionTimeout` value is configured as the `max-idle-seconds` for the session map in Hazelcast. So, the session expiry in Hazelcast cluster happens at the same time with Tomcat by default. However, if you would like to change the expiration setting on the Hazelcast cluster, you need to configure eviction for the related session map. Please see the Hazelcast's own eviction mechanism details [here](https://docs.hazelcast.org/docs/latest/manual/html-single/#map-eviction).
+Please note that if you change the Hazelcast's eviction configuration, the sessions might be kept alive longer than the `sessionTimeout` setting.         
+
 # Enabling Session Replication in Multi-App Environments
 
 Tomcat can be configured in two ways to enable Session Replication for deployed applications.

--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSession.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 public class HazelcastSession extends StandardSession implements DataSerializable {
 
@@ -95,6 +96,24 @@ public class HazelcastSession extends StandardSession implements DataSerializabl
                 this.thisAccessedTime = distributedSession.thisAccessedTime;
             }
         }
+    }
+
+    @Override
+    public void setMaxInactiveInterval(int interval) {
+        super.setMaxInactiveInterval(interval);
+        updateSessionWithMaxIdleSeconds(interval);
+        if (LOG.isDebugEnabled()) {
+            LOG.info("Session 'maxInactiveInterval' updated on Hazelcast cluster.");
+        }
+    }
+
+    private void updateSessionWithMaxIdleSeconds(int interval) {
+        sessionManager.getDistributedMap()
+                      .set(id, this, -1, TimeUnit.MILLISECONDS, interval, TimeUnit.SECONDS);
+    }
+
+    void setMaxInactiveIntervalLocal(int interval) {
+        super.setMaxInactiveInterval(interval);
     }
 
     public boolean isDirty() {

--- a/tomcat-core/src/test/java/com/hazelcast/session/AbstractHazelcastSessionsTest.java
+++ b/tomcat-core/src/test/java/com/hazelcast/session/AbstractHazelcastSessionsTest.java
@@ -3,15 +3,19 @@ package com.hazelcast.session;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.test.HazelcastTestSupport;
+import org.apache.catalina.Manager;
+import org.apache.catalina.session.StandardSession;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 
+import java.io.IOException;
 import java.net.ServerSocket;
 
 public abstract class AbstractHazelcastSessionsTest extends HazelcastTestSupport {
@@ -39,6 +43,34 @@ public abstract class AbstractHazelcastSessionsTest extends HazelcastTestSupport
         HttpResponse response = client.execute(request);
         HttpEntity entity = response.getEntity();
         return EntityUtils.toString(entity);
+    }
+
+    /**
+     * Helper method to retrieve the JSESSIONID value from the {@link CookieStore}.
+     * @param cookieStore the cookie store containing sessions.
+     * @return the value of the JSESSIONID cookie if present, otherwise null.
+     */
+    protected static String getJSessionId(CookieStore cookieStore) {
+        String jSessionId = null;
+        for (Cookie cookie : cookieStore.getCookies()) {
+            if ("JSESSIONID".equalsIgnoreCase(cookie.getName())) {
+                jSessionId = cookie.getValue();
+            }
+        }
+        return jSessionId;
+    }
+
+    /**
+     * Retrieves sessions using {@link Manager#findSession(String)} in accordance with the {@link StandardSession#isValid()}
+     * method.
+     *
+     * @param jSessionId the session id.
+     * @param instance the tomcat instance.
+     * @return the instance of {@link HazelcastSession} if present, otherwise null.
+     */
+    protected static HazelcastSession getHazelcastSession(String jSessionId, WebContainerConfigurator<?> instance)
+            throws IOException {
+        return (HazelcastSession) ((Manager) instance.getManager()).findSession(jSessionId);
     }
 
     /**

--- a/tomcat-core/src/test/java/com/hazelcast/session/AbstractSessionExpireTest.java
+++ b/tomcat-core/src/test/java/com/hazelcast/session/AbstractSessionExpireTest.java
@@ -25,13 +25,7 @@ public abstract class AbstractSessionExpireTest extends AbstractHazelcastSession
         final int SESSION_TIMEOUT_IN_MINUTES = 1;
         final int EXTRA_DELAY_IN_SECONDS = 5;
 
-        instance1 = getWebContainerConfigurator();
-        instance1.port(SERVER_PORT_1).sticky(true).clientOnly(false).mapName(SESSION_REPLICATION_MAP_NAME)
-                 .sessionTimeout(SESSION_TIMEOUT_IN_MINUTES).configLocation(firstConfig).start();
-
-        instance2 = getWebContainerConfigurator();
-        instance2.port(SERVER_PORT_2).sticky(true).clientOnly(false).mapName(SESSION_REPLICATION_MAP_NAME)
-                 .sessionTimeout(SESSION_TIMEOUT_IN_MINUTES).configLocation(secondConfig).start();
+        initializeInstances(firstConfig, secondConfig, SESSION_TIMEOUT_IN_MINUTES);
 
         CookieStore cookieStore = new BasicCookieStore();
         executeRequest("write", SERVER_PORT_1, cookieStore);
@@ -40,15 +34,60 @@ public abstract class AbstractSessionExpireTest extends AbstractHazelcastSession
 
         instance1.stop();
 
-        HazelcastInstance hzInstance1 = Hazelcast.getHazelcastInstanceByName("hzInstance1");
-        if (hzInstance1 != null) {
-            hzInstance1.shutdown();
-        }
+        shutdownHzInstance1();
 
         sleepSeconds(SESSION_TIMEOUT_IN_MINUTES * 60 + EXTRA_DELAY_IN_SECONDS);
 
         assertEquals(expectedSessionCount, instance2.getManager().getDistributedMap().size());
 
         instance2.stop();
+    }
+
+    @Test
+    public void testSessionExpireAfterFailoverAndSessionTimeout_withSessionSpecificTimeout()
+            throws Exception {
+        final int GENERIC_SESSION_TIMEOUT_IN_MINUTES = 10;
+        final int SPECIFIC_SESSION_TIMEOUT_IN_MINUTES = 1;
+        final int EXTRA_DELAY_IN_SECONDS = 5;
+
+        initializeInstances("hazelcast-1.xml", "hazelcast-2.xml", GENERIC_SESSION_TIMEOUT_IN_MINUTES);
+
+        CookieStore cookieStore = new BasicCookieStore();
+        executeRequest("write", SERVER_PORT_1, cookieStore);
+
+        String sessionId = getJSessionId(cookieStore);
+        HazelcastSession session = getHazelcastSession(sessionId, instance1);
+        session.setMaxInactiveInterval(SPECIFIC_SESSION_TIMEOUT_IN_MINUTES);
+
+        String value = executeRequest("read", SERVER_PORT_1, cookieStore);
+        assertEquals("value", value);
+
+        instance1.stop();
+
+        shutdownHzInstance1();
+
+        sleepSeconds(SPECIFIC_SESSION_TIMEOUT_IN_MINUTES * 60 + EXTRA_DELAY_IN_SECONDS);
+
+        assertEquals(0, instance2.getManager().getDistributedMap().size());
+
+        instance2.stop();
+    }
+
+    private void shutdownHzInstance1() {
+        HazelcastInstance hzInstance1 = Hazelcast.getHazelcastInstanceByName("hzInstance1");
+        if (hzInstance1 != null) {
+            hzInstance1.shutdown();
+        }
+    }
+
+    private void initializeInstances(String firstConfig, String secondConfig, int sessionTimeout)
+            throws Exception {
+        instance1 = getWebContainerConfigurator();
+        instance1.port(SERVER_PORT_1).sticky(true).clientOnly(false).mapName(SESSION_REPLICATION_MAP_NAME)
+                 .sessionTimeout(sessionTimeout).configLocation(firstConfig).start();
+
+        instance2 = getWebContainerConfigurator();
+        instance2.port(SERVER_PORT_2).sticky(true).clientOnly(false).mapName(SESSION_REPLICATION_MAP_NAME)
+                 .sessionTimeout(sessionTimeout).configLocation(secondConfig).start();
     }
 }

--- a/tomcat-core/src/test/java/com/hazelcast/session/nonsticky/AbstractNonStickySessionsTest.java
+++ b/tomcat-core/src/test/java/com/hazelcast/session/nonsticky/AbstractNonStickySessionsTest.java
@@ -6,15 +6,9 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.session.AbstractHazelcastSessionsTest;
 import com.hazelcast.session.CustomAttribute;
 import com.hazelcast.session.HazelcastSession;
-import com.hazelcast.session.WebContainerConfigurator;
-import org.apache.catalina.Manager;
-import org.apache.catalina.session.StandardSession;
 import org.apache.http.client.CookieStore;
-import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.junit.Test;
-
-import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -160,33 +154,4 @@ public abstract class AbstractNonStickySessionsTest extends AbstractHazelcastSes
     }
 
     public abstract void validateSessionAccessTime(HazelcastSession session1, HazelcastSession session2);
-
-
-    /**
-     * Helper method to retrieve the JSESSIONID value from the {@link CookieStore}.
-     * @param cookieStore the cookie store containing sessions.
-     * @return the value of the JSESSIONID cookie if present, otherwise null.
-     */
-    private static String getJSessionId(CookieStore cookieStore) {
-        String jSessionId = null;
-        for (Cookie cookie : cookieStore.getCookies()) {
-            if ("JSESSIONID".equalsIgnoreCase(cookie.getName())) {
-                jSessionId = cookie.getValue();
-            }
-        }
-        return jSessionId;
-    }
-
-    /**
-     * Retrieves sessions using {@link Manager#findSession(String)} in accordance with the {@link StandardSession#isValid()}
-     * method.
-     *
-     * @param jSessionId the session id.
-     * @param instance the tomcat instance.
-     * @return the instance of {@link HazelcastSession} if present, otherwise null.
-     */
-    private static HazelcastSession getHazelcastSession(String jSessionId, WebContainerConfigurator<?> instance)
-            throws IOException {
-        return (HazelcastSession) ((Manager) instance.getManager()).findSession(jSessionId);
-    }
 }

--- a/tomcat-core/src/test/java/com/hazelcast/session/nonsticky/AbstractNonStickySessionsTest.java
+++ b/tomcat-core/src/test/java/com/hazelcast/session/nonsticky/AbstractNonStickySessionsTest.java
@@ -8,12 +8,13 @@ import com.hazelcast.session.CustomAttribute;
 import com.hazelcast.session.HazelcastSession;
 import com.hazelcast.session.WebContainerConfigurator;
 import org.apache.catalina.Manager;
-import org.apache.catalina.Session;
 import org.apache.catalina.session.StandardSession;
 import org.apache.http.client.CookieStore;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -177,23 +178,15 @@ public abstract class AbstractNonStickySessionsTest extends AbstractHazelcastSes
     }
 
     /**
-     * Retrieves sessions using {@link Manager#findSessions()} in accordance with the {@link StandardSession#isValid()}
+     * Retrieves sessions using {@link Manager#findSession(String)} in accordance with the {@link StandardSession#isValid()}
      * method.
      *
      * @param jSessionId the session id.
      * @param instance the tomcat instance.
      * @return the instance of {@link HazelcastSession} if present, otherwise null.
      */
-    private static HazelcastSession getHazelcastSession(String jSessionId, WebContainerConfigurator<?> instance) {
-        Session[] allSessions = ((Manager) instance.getManager()).findSessions();
-
-        HazelcastSession hzSession = null;
-        for (Session session : allSessions) {
-            if (jSessionId.equals(session.getId())) {
-                hzSession = (HazelcastSession) session;
-                break;
-            }
-        }
-        return hzSession;
+    private static HazelcastSession getHazelcastSession(String jSessionId, WebContainerConfigurator<?> instance)
+            throws IOException {
+        return (HazelcastSession) ((Manager) instance.getManager()).findSession(jSessionId);
     }
 }

--- a/tomcat-core/src/test/resources/hazelcast-1.xml
+++ b/tomcat-core/src/test/resources/hazelcast-1.xml
@@ -26,4 +26,8 @@
             </tcp-ip>
         </join>
     </network>
+
+    <map name="session-replication-map">
+        <max-idle-seconds>60</max-idle-seconds>
+    </map>
 </hazelcast>

--- a/tomcat-core/src/test/resources/hazelcast-2.xml
+++ b/tomcat-core/src/test/resources/hazelcast-2.xml
@@ -26,4 +26,8 @@
             </tcp-ip>
         </join>
     </network>
+
+    <map name="session-replication-map">
+        <max-idle-seconds>60</max-idle-seconds>
+    </map>
 </hazelcast>

--- a/tomcat-core/src/test/resources/hazelcast-3.xml
+++ b/tomcat-core/src/test/resources/hazelcast-3.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <instance-name>hzInstance1</instance-name>
+    <network>
+        <port auto-increment="true">5701</port>
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+        </join>
+    </network>
+
+    <map name="session-replication-map">
+        <max-idle-seconds>600</max-idle-seconds>
+    </map>
+</hazelcast>

--- a/tomcat-core/src/test/resources/hazelcast-4.xml
+++ b/tomcat-core/src/test/resources/hazelcast-4.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Hazelcast Inc.
+  ~
+  ~ Licensed under the Hazelcast Community License (the "License"); you may not use
+  ~ this file except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://hazelcast.com/hazelcast-community-license
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  -->
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <instance-name>hzInstance2</instance-name>
+    <network>
+        <port auto-increment="true">5701</port>
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+        </join>
+    </network>
+
+    <map name="session-replication-map">
+        <max-idle-seconds>600</max-idle-seconds>
+    </map>
+</hazelcast>

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -15,8 +15,6 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.apache.catalina.Context;

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -170,7 +170,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(getMaxInactiveInterval());
+        session.setMaxInactiveIntervalLocal(getMaxInactiveInterval());
 
         String newSessionId = sessionId;
         if (newSessionId == null) {

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -15,6 +15,8 @@
 
 package com.hazelcast.session;
 
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.apache.catalina.Context;
@@ -30,10 +32,6 @@ import org.apache.juli.logging.LogFactory;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 public class HazelcastSessionManager extends ManagerBase implements Lifecycle, PropertyChangeListener, SessionManager {
 
@@ -71,11 +69,11 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
     }
 
     @Override
-    public void load() throws ClassNotFoundException, IOException {
+    public void load() {
     }
 
     @Override
-    public void unload() throws IOException {
+    public void unload() {
     }
 
     @Override
@@ -103,21 +101,27 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         instance = HazelcastInstanceFactory.
                 getHazelcastInstance(getContainer().getLoader().getClassLoader(), isClientOnly(), getHazelcastInstanceName());
 
+        String mapName;
         if (getMapName() == null || "default".equals(getMapName())) {
             Context ctx = (Context) getContainer();
             String contextPath = ctx.getServletContext().getContextPath();
             log.debug("contextPath: " + contextPath);
-            String mapName;
             if (contextPath == null || contextPath.equals("/") || contextPath.equals("")) {
                 mapName = "empty_session_replication";
             } else {
-                mapName = contextPath.substring(1, contextPath.length()) + "_session_replication";
+                mapName = contextPath.substring(1) + "_session_replication";
             }
-            sessionMap = instance.getMap(mapName);
         } else {
-            sessionMap = instance.getMap(getMapName());
+            mapName = getMapName();
         }
 
+        try {
+            instance.getConfig().addMapConfig(new MapConfig(mapName).setMaxIdleSeconds(getMaxInactiveInterval()));
+        } catch (InvalidConfigurationException e) {
+            log.info("Max idle seconds cannot be setup, \"" + mapName
+                    + "\" map is already configured in the Hazelcast cluster!");
+        }
+        sessionMap = instance.getMap(mapName);
         if (!isSticky()) {
             sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);
         }
@@ -158,10 +162,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         return 0;
     }
 
-    public void setRejectedSessions(int i) {
-        // Do nothing.
-    }
-
     @Override
     public Session createSession(String sessionId) {
         checkMaxActiveSessions();
@@ -192,12 +192,12 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
     @Override
     public void add(Session session) {
-        sessions.put(session.getId(), (HazelcastSession) session);
+        sessions.put(session.getId(), session);
         sessionMap.set(session.getId(), (HazelcastSession) session);
     }
 
     @Override
-    public Session findSession(String id) throws IOException {
+    public Session findSession(String id) {
         log.debug("sessionId: " + id);
         if (id == null) {
             return null;
@@ -239,31 +239,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
     }
 
-    @Override
-    public Session[] findSessions() {
-        // Get all local sessions
-        Set<Session> allSessions = new HashSet<Session>(sessions.values());
-
-        // Get all non-local sessions ids
-        Set<String> keys = new HashSet<String>(sessionMap.keySet());
-        keys.removeAll(sessions.keySet());
-
-        // Get all non-local sessions
-        final Collection<HazelcastSession> nonLocalSessions = sessionMap.getAll(keys).values();
-
-        // Set SessionManager since it's a transient field
-        for (HazelcastSession nonLocalSession : nonLocalSessions) {
-            if (nonLocalSession.getManager() == null) {
-                nonLocalSession.setSessionManager(this);
-            }
-        }
-
-        // Add all non-local sessions
-        allSessions.addAll(nonLocalSessions);
-
-        return allSessions.toArray(new Session[allSessions.size()]);
-    }
-
     public void commit(Session session) {
         HazelcastSession hazelcastSession = (HazelcastSession) session;
         if (hazelcastSession.isDirty()) {
@@ -276,7 +251,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
     }
 
     @Override
-    public String updateJvmRouteForSession(String sessionId, String newJvmRoute) throws IOException {
+    public String updateJvmRouteForSession(String sessionId, String newJvmRoute) {
         HazelcastSession session = sessionMap.get(sessionId);
         if (session == null) {
             session = (HazelcastSession) createSession(null);

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -115,12 +115,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             mapName = getMapName();
         }
 
-        try {
-            instance.getConfig().addMapConfig(new MapConfig(mapName).setMaxIdleSeconds(getMaxInactiveInterval()));
-        } catch (InvalidConfigurationException e) {
-            log.info("Max idle seconds cannot be setup, \"" + mapName
-                    + "\" map is already configured in the Hazelcast cluster!");
-        }
         sessionMap = instance.getMap(mapName);
         if (!isSticky()) {
             sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);

--- a/tomcat7/src/test/java/com/hazelcast/session/Tomcat7AsyncConfigurator.java
+++ b/tomcat7/src/test/java/com/hazelcast/session/Tomcat7AsyncConfigurator.java
@@ -1,6 +1,9 @@
 package com.hazelcast.session;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
@@ -58,6 +61,14 @@ public class Tomcat7AsyncConfigurator extends WebContainerConfigurator<Tomcat> {
         context.setCookies(true);
         context.setBackgroundProcessorDelay(1);
         context.setReloadable(true);
+        context.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void lifecycleEvent(LifecycleEvent event) {
+                if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+                    ((Context) event.getLifecycle()).setSessionTimeout(sessionTimeout);
+                }
+            }
+        });
 
         return tomcat;
     }

--- a/tomcat7/src/test/java/com/hazelcast/session/Tomcat7Configurator.java
+++ b/tomcat7/src/test/java/com/hazelcast/session/Tomcat7Configurator.java
@@ -1,6 +1,9 @@
 package com.hazelcast.session;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 
@@ -60,6 +63,14 @@ public class Tomcat7Configurator extends WebContainerConfigurator<Tomcat> {
         context.setCookies(true);
         context.setBackgroundProcessorDelay(1);
         context.setReloadable(true);
+        context.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void lifecycleEvent(LifecycleEvent event) {
+                if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+                    ((Context) event.getLifecycle()).setSessionTimeout(sessionTimeout);
+                }
+            }
+        });
 
         return tomcat;
     }

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -172,7 +172,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(getMaxInactiveInterval());
+        session.setMaxInactiveIntervalLocal(getMaxInactiveInterval());
 
         String newSessionId = sessionId;
         if (newSessionId == null) {

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -15,6 +15,8 @@
 
 package com.hazelcast.session;
 
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.apache.catalina.Context;
@@ -30,10 +32,6 @@ import org.apache.juli.logging.LogFactory;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 public class HazelcastSessionManager extends ManagerBase implements Lifecycle, PropertyChangeListener, SessionManager {
 
@@ -69,11 +67,11 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
     }
 
     @Override
-    public void load() throws ClassNotFoundException, IOException {
+    public void load() {
     }
 
     @Override
-    public void unload() throws IOException {
+    public void unload() {
     }
 
     @Override
@@ -101,21 +99,27 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         instance = HazelcastInstanceFactory.
                 getHazelcastInstance(getContext().getLoader().getClassLoader(), isClientOnly(), getHazelcastInstanceName());
 
+        String mapName;
         if (getMapName() == null || "default".equals(getMapName())) {
             Context ctx = getContext();
             String contextPath = ctx.getServletContext().getContextPath();
             log.debug("contextPath: " + contextPath);
-            String mapName;
             if (contextPath == null || contextPath.equals("/") || contextPath.equals("")) {
                 mapName = "empty_session_replication";
             } else {
-                mapName = contextPath.substring(1, contextPath.length()) + "_session_replication";
+                mapName = contextPath.substring(1) + "_session_replication";
             }
-            sessionMap = instance.getMap(mapName);
         } else {
-            sessionMap = instance.getMap(getMapName());
+            mapName = getMapName();
         }
 
+        try {
+            instance.getConfig().addMapConfig(new MapConfig(mapName).setMaxIdleSeconds(getMaxInactiveInterval()));
+        } catch (InvalidConfigurationException e) {
+            log.info("Max idle seconds cannot be setup, \"" + mapName
+                    + "\" map is already configured in the Hazelcast cluster!");
+        }
+        sessionMap = instance.getMap(mapName);
         if (!isSticky()) {
             sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);
         }
@@ -190,12 +194,12 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
     @Override
     public void add(Session session) {
-        sessions.put(session.getId(), (HazelcastSession) session);
+        sessions.put(session.getId(), session);
         sessionMap.set(session.getId(), (HazelcastSession) session);
     }
 
     @Override
-    public Session findSession(String id) throws IOException {
+    public Session findSession(String id) {
         log.debug("sessionId: " + id);
         if (id == null) {
             return null;
@@ -236,31 +240,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
     }
 
-    @Override
-    public Session[] findSessions() {
-        // Get all local sessions
-        Set<Session> allSessions = new HashSet<Session>(sessions.values());
-
-        // Get all non-local sessions ids
-        Set<String> keys = new HashSet<String>(sessionMap.keySet());
-        keys.removeAll(sessions.keySet());
-
-        // Get all non-local sessions
-        final Collection<HazelcastSession> nonLocalSessions = sessionMap.getAll(keys).values();
-
-        // Set SessionManager since it's a transient field
-        for (HazelcastSession nonLocalSession : nonLocalSessions) {
-            if (nonLocalSession.getManager() == null) {
-                nonLocalSession.setSessionManager(this);
-            }
-        }
-
-        // Add all non-local sessions
-        allSessions.addAll(nonLocalSessions);
-
-        return allSessions.toArray(new Session[allSessions.size()]);
-    }
-
     public void commit(Session session) {
         HazelcastSession hazelcastSession = (HazelcastSession) session;
         if (hazelcastSession.isDirty()) {
@@ -273,7 +252,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
     }
 
     @Override
-    public String updateJvmRouteForSession(String sessionId, String newJvmRoute) throws IOException {
+    public String updateJvmRouteForSession(String sessionId, String newJvmRoute) {
         HazelcastSession session = sessionMap.get(sessionId);
         if (session == null) {
             session = (HazelcastSession) createSession(null);

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -15,8 +15,6 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.apache.catalina.Context;

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -113,12 +113,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             mapName = getMapName();
         }
 
-        try {
-            instance.getConfig().addMapConfig(new MapConfig(mapName).setMaxIdleSeconds(getMaxInactiveInterval()));
-        } catch (InvalidConfigurationException e) {
-            log.info("Max idle seconds cannot be setup, \"" + mapName
-                    + "\" map is already configured in the Hazelcast cluster!");
-        }
         sessionMap = instance.getMap(mapName);
         if (!isSticky()) {
             sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);

--- a/tomcat8/src/test/java/com/hazelcast/session/Tomcat8AsyncConfigurator.java
+++ b/tomcat8/src/test/java/com/hazelcast/session/Tomcat8AsyncConfigurator.java
@@ -1,6 +1,9 @@
 package com.hazelcast.session;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
@@ -58,6 +61,14 @@ public class Tomcat8AsyncConfigurator extends WebContainerConfigurator<Tomcat> {
         context.setCookies(true);
         context.setBackgroundProcessorDelay(1);
         context.setReloadable(true);
+        context.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void lifecycleEvent(LifecycleEvent event) {
+                if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+                    ((Context) event.getLifecycle()).setSessionTimeout(sessionTimeout);
+                }
+            }
+        });
 
         return tomcat;
     }
@@ -66,7 +77,6 @@ public class Tomcat8AsyncConfigurator extends WebContainerConfigurator<Tomcat> {
     public void start() throws Exception {
         tomcat = configure();
         tomcat.start();
-        setSessionTimeout();
     }
 
     @Override
@@ -83,7 +93,6 @@ public class Tomcat8AsyncConfigurator extends WebContainerConfigurator<Tomcat> {
             context = (Context) tomcat.getHost().findChild("");
         }
         context.reload();
-        setSessionTimeout();
     }
 
     @Override
@@ -97,9 +106,5 @@ public class Tomcat8AsyncConfigurator extends WebContainerConfigurator<Tomcat> {
         manager.setMapName(mapName);
         manager.setDeferredWrite(deferredWrite);
         manager.setProcessExpiresFrequency(1);
-    }
-
-    private void setSessionTimeout() {
-        manager.setSessionTimeout(sessionTimeout);
     }
 }

--- a/tomcat8/src/test/java/com/hazelcast/session/Tomcat8Configurator.java
+++ b/tomcat8/src/test/java/com/hazelcast/session/Tomcat8Configurator.java
@@ -1,6 +1,9 @@
 package com.hazelcast.session;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 
@@ -63,6 +66,14 @@ public class Tomcat8Configurator extends WebContainerConfigurator<Tomcat> {
         context.setCookies(true);
         context.setBackgroundProcessorDelay(1);
         context.setReloadable(true);
+        context.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void lifecycleEvent(LifecycleEvent event) {
+                if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+                    ((Context) event.getLifecycle()).setSessionTimeout(sessionTimeout);
+                }
+            }
+        });
 
         return tomcat;
     }
@@ -71,7 +82,6 @@ public class Tomcat8Configurator extends WebContainerConfigurator<Tomcat> {
     public void start() throws Exception {
         tomcat = configure();
         tomcat.start();
-        setSessionTimeout();
     }
 
     @Override
@@ -89,7 +99,6 @@ public class Tomcat8Configurator extends WebContainerConfigurator<Tomcat> {
             context = (Context) tomcat.getHost().findChild("");
         }
         context.reload();
-        setSessionTimeout();
     }
 
     @Override
@@ -103,9 +112,5 @@ public class Tomcat8Configurator extends WebContainerConfigurator<Tomcat> {
         manager.setMapName(mapName);
         manager.setDeferredWrite(deferredWrite);
         manager.setProcessExpiresFrequency(1);
-    }
-
-    private void setSessionTimeout() {
-        manager.setSessionTimeout(sessionTimeout);
     }
 }

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -15,6 +15,8 @@
 
 package com.hazelcast.session;
 
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.apache.catalina.Context;
@@ -28,10 +30,6 @@ import org.apache.juli.logging.LogFactory;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 public class HazelcastSessionManager extends ManagerBase implements Lifecycle, PropertyChangeListener, SessionManager {
 
@@ -67,11 +65,11 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
     }
 
     @Override
-    public void load() throws ClassNotFoundException, IOException {
+    public void load() {
     }
 
     @Override
-    public void unload() throws IOException {
+    public void unload() {
     }
 
     @Override
@@ -91,13 +89,19 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             if (contextPath == null || contextPath.equals("/") || contextPath.equals("")) {
                 mapName = "empty_session_replication";
             } else {
-                mapName = contextPath.substring(1, contextPath.length()) + "_session_replication";
+                mapName = contextPath.substring(1) + "_session_replication";
             }
-            sessionMap = instance.getMap(mapName);
         } else {
-            sessionMap = instance.getMap(getMapName());
+            mapName = getMapName();
         }
 
+        try {
+            instance.getConfig().addMapConfig(new MapConfig(mapName).setMaxIdleSeconds(getSessionTimeoutInSeconds()));
+        } catch (InvalidConfigurationException e) {
+            log.info("Max idle seconds cannot be setup, \"" + mapName
+                    + "\" map is already configured in the Hazelcast cluster!");
+        }
+        sessionMap = instance.getMap(mapName);
         if (!isSticky()) {
             sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);
         }
@@ -138,10 +142,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         return 0;
     }
 
-    public void setRejectedSessions(int i) {
-        // Do nothing.
-    }
-
     @Override
     public Session createSession(String sessionId) {
         checkMaxActiveSessions();
@@ -150,7 +150,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(getContext().getSessionTimeout() * SECONDS_IN_MINUTE);
+        session.setMaxInactiveInterval(getSessionTimeoutInSeconds());
 
         String newSessionId = sessionId;
         if (newSessionId == null) {
@@ -165,6 +165,10 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         return session;
     }
 
+    private int getSessionTimeoutInSeconds() {
+        return getContext().getSessionTimeout() * SECONDS_IN_MINUTE;
+    }
+
     @Override
     public Session createEmptySession() {
         return new HazelcastSession(this);
@@ -172,12 +176,12 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
     @Override
     public void add(Session session) {
-        sessions.put(session.getId(), (HazelcastSession) session);
+        sessions.put(session.getId(), session);
         sessionMap.set(session.getId(), (HazelcastSession) session);
     }
 
     @Override
-    public Session findSession(String id) throws IOException {
+    public Session findSession(String id) {
         log.debug("Attempting to find sessionId: " + id);
 
         if (id == null) {
@@ -221,31 +225,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         }
     }
 
-    @Override
-    public Session[] findSessions() {
-        // Get all local sessions
-        Set<Session> allSessions = new HashSet<Session>(sessions.values());
-
-        // Get all non-local sessions ids
-        Set<String> keys = new HashSet<String>(sessionMap.keySet());
-        keys.removeAll(sessions.keySet());
-
-        // Get all non-local sessions
-        final Collection<HazelcastSession> nonLocalSessions = sessionMap.getAll(keys).values();
-
-        // Set SessionManager since it's a transient field
-        for (HazelcastSession nonLocalSession : nonLocalSessions) {
-            if (nonLocalSession.getManager() == null) {
-                nonLocalSession.setSessionManager(this);
-            }
-        }
-
-        // Add all non-local sessions
-        allSessions.addAll(nonLocalSessions);
-
-        return allSessions.toArray(new Session[allSessions.size()]);
-    }
-
     public void commit(Session session) {
         HazelcastSession hazelcastSession = (HazelcastSession) session;
         if (hazelcastSession.isDirty()) {
@@ -258,7 +237,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
     }
 
     @Override
-    public String updateJvmRouteForSession(String sessionId, String newJvmRoute) throws IOException {
+    public String updateJvmRouteForSession(String sessionId, String newJvmRoute) {
         HazelcastSession session = sessionMap.get(sessionId);
         if (session == null) {
             session = (HazelcastSession) createSession(null);

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -150,7 +150,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(getSessionTimeoutInSeconds());
+        session.setMaxInactiveIntervalLocal(getSessionTimeoutInSeconds());
 
         String newSessionId = sessionId;
         if (newSessionId == null) {

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -95,12 +95,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             mapName = getMapName();
         }
 
-        try {
-            instance.getConfig().addMapConfig(new MapConfig(mapName).setMaxIdleSeconds(getSessionTimeoutInSeconds()));
-        } catch (InvalidConfigurationException e) {
-            log.info("Max idle seconds cannot be setup, \"" + mapName
-                    + "\" map is already configured in the Hazelcast cluster!");
-        }
         sessionMap = instance.getMap(mapName);
         if (!isSticky()) {
             sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -15,8 +15,6 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.apache.catalina.Context;

--- a/tomcat85/src/test/java/com/hazelcast/session/Tomcat85AsyncConfigurator.java
+++ b/tomcat85/src/test/java/com/hazelcast/session/Tomcat85AsyncConfigurator.java
@@ -1,6 +1,9 @@
 package com.hazelcast.session;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
@@ -58,6 +61,14 @@ public class Tomcat85AsyncConfigurator extends WebContainerConfigurator<Tomcat> 
         context.setCookies(true);
         context.setBackgroundProcessorDelay(1);
         context.setReloadable(true);
+        context.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void lifecycleEvent(LifecycleEvent event) {
+                if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+                    ((Context) event.getLifecycle()).setSessionTimeout(sessionTimeout);
+                }
+            }
+        });
 
         return tomcat;
     }
@@ -66,7 +77,6 @@ public class Tomcat85AsyncConfigurator extends WebContainerConfigurator<Tomcat> 
     public void start() throws Exception {
         tomcat = configure();
         tomcat.start();
-        setSessionTimeout();
     }
 
     @Override
@@ -83,7 +93,6 @@ public class Tomcat85AsyncConfigurator extends WebContainerConfigurator<Tomcat> 
             context = (Context) tomcat.getHost().findChild("");
         }
         context.reload();
-        setSessionTimeout();
     }
 
     @Override
@@ -97,9 +106,5 @@ public class Tomcat85AsyncConfigurator extends WebContainerConfigurator<Tomcat> 
         manager.setMapName(mapName);
         manager.setDeferredWrite(deferredWrite);
         manager.setProcessExpiresFrequency(1);
-    }
-
-    private void setSessionTimeout() {
-        manager.setSessionTimeout(sessionTimeout);
     }
 }

--- a/tomcat85/src/test/java/com/hazelcast/session/Tomcat85Configurator.java
+++ b/tomcat85/src/test/java/com/hazelcast/session/Tomcat85Configurator.java
@@ -1,6 +1,9 @@
 package com.hazelcast.session;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 
@@ -63,6 +66,14 @@ public class Tomcat85Configurator extends WebContainerConfigurator<Tomcat> {
         context.setCookies(true);
         context.setBackgroundProcessorDelay(1);
         context.setReloadable(true);
+        context.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void lifecycleEvent(LifecycleEvent event) {
+                if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+                    ((Context) event.getLifecycle()).setSessionTimeout(sessionTimeout);
+                }
+            }
+        });
 
         return tomcat;
     }
@@ -71,7 +82,6 @@ public class Tomcat85Configurator extends WebContainerConfigurator<Tomcat> {
     public void start() throws Exception {
         tomcat = configure();
         tomcat.start();
-        setSessionTimeout();
     }
 
     @Override
@@ -89,7 +99,6 @@ public class Tomcat85Configurator extends WebContainerConfigurator<Tomcat> {
             context = (Context) tomcat.getHost().findChild("");
         }
         context.reload();
-        setSessionTimeout();
     }
 
     @Override
@@ -103,9 +112,5 @@ public class Tomcat85Configurator extends WebContainerConfigurator<Tomcat> {
         manager.setMapName(mapName);
         manager.setDeferredWrite(deferredWrite);
         manager.setProcessExpiresFrequency(1);
-    }
-
-    private void setSessionTimeout() {
-        manager.setSessionTimeout(sessionTimeout);
     }
 }

--- a/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -146,7 +146,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
         session.setNew(true);
         session.setValid(true);
         session.setCreationTime(System.currentTimeMillis());
-        session.setMaxInactiveInterval(getSessionTimeoutInSeconds());
+        session.setMaxInactiveIntervalLocal(getSessionTimeoutInSeconds());
 
         String newSessionId = sessionId;
         if (newSessionId == null) {

--- a/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -15,8 +15,6 @@
 
 package com.hazelcast.session;
 
-import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.apache.catalina.Context;

--- a/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -91,12 +91,6 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             mapName = getMapName();
         }
 
-        try {
-            instance.getConfig().addMapConfig(new MapConfig(mapName).setMaxIdleSeconds(getSessionTimeoutInSeconds()));
-        } catch (InvalidConfigurationException e) {
-            log.info("Max idle seconds cannot be setup, \"" + mapName
-                    + "\" map is already configured in the Hazelcast cluster!");
-        }
         sessionMap = instance.getMap(mapName);
         if (!isSticky()) {
             sessionMap.addEntryListener(new LocalSessionsInvalidateListener(sessions), false);

--- a/tomcat9/src/test/java/com/hazelcast/session/Tomcat9AsyncConfigurator.java
+++ b/tomcat9/src/test/java/com/hazelcast/session/Tomcat9AsyncConfigurator.java
@@ -1,6 +1,9 @@
 package com.hazelcast.session;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.Wrapper;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
@@ -59,6 +62,14 @@ public class Tomcat9AsyncConfigurator
         context.setCookies(true);
         context.setBackgroundProcessorDelay(1);
         context.setReloadable(true);
+        context.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void lifecycleEvent(LifecycleEvent event) {
+                if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+                    ((Context) event.getLifecycle()).setSessionTimeout(sessionTimeout);
+                }
+            }
+        });
 
         return tomcat;
     }
@@ -67,7 +78,6 @@ public class Tomcat9AsyncConfigurator
     public void start() throws Exception {
         tomcat = configure();
         tomcat.start();
-        setSessionTimeout();
     }
 
     @Override
@@ -84,7 +94,6 @@ public class Tomcat9AsyncConfigurator
             context = (Context) tomcat.getHost().findChild("");
         }
         context.reload();
-        setSessionTimeout();
     }
 
     @Override
@@ -98,9 +107,5 @@ public class Tomcat9AsyncConfigurator
         manager.setMapName(mapName);
         manager.setDeferredWrite(deferredWrite);
         manager.setProcessExpiresFrequency(1);
-    }
-
-    private void setSessionTimeout() {
-        manager.setSessionTimeout(sessionTimeout);
     }
 }

--- a/tomcat9/src/test/java/com/hazelcast/session/Tomcat9Configurator.java
+++ b/tomcat9/src/test/java/com/hazelcast/session/Tomcat9Configurator.java
@@ -1,6 +1,9 @@
 package com.hazelcast.session;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleEvent;
+import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
 
@@ -64,6 +67,14 @@ public class Tomcat9Configurator
         context.setCookies(true);
         context.setBackgroundProcessorDelay(1);
         context.setReloadable(true);
+        context.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void lifecycleEvent(LifecycleEvent event) {
+                if (Lifecycle.BEFORE_START_EVENT.equals(event.getType())) {
+                    ((Context) event.getLifecycle()).setSessionTimeout(sessionTimeout);
+                }
+            }
+        });
 
         return tomcat;
     }
@@ -72,7 +83,6 @@ public class Tomcat9Configurator
     public void start() throws Exception {
         tomcat = configure();
         tomcat.start();
-        setSessionTimeout();
     }
 
     @Override
@@ -90,7 +100,6 @@ public class Tomcat9Configurator
             context = (Context) tomcat.getHost().findChild("");
         }
         context.reload();
-        setSessionTimeout();
     }
 
     @Override
@@ -104,9 +113,5 @@ public class Tomcat9Configurator
         manager.setMapName(mapName);
         manager.setDeferredWrite(deferredWrite);
         manager.setProcessExpiresFrequency(1);
-    }
-
-    private void setSessionTimeout() {
-        manager.setSessionTimeout(sessionTimeout);
     }
 }


### PR DESCRIPTION
Before this change, Tomcat's background process for expiration was retrieving all the remote sessions to local to check & expire them. This can cause OOMEs when the total session size is larger than the local container's heap. 

To prevent that, the expiration of the sessions in the Hazelcast cluster is separated from Tomcat. Now, Hazelcast's `max-idle-seconds` property is set to `sessionTimeout` value by default to define expiry policy on the cluster side. The configuration is done by adding a dynamic map config to the Hazelcast cluster if there is no configuration for this map in the cluster. If so, then the existing cluster configuration has the priority.

Fixes #83.

