### PR TITLE
Added property to enable/disable Spring Boot autoconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ When Tomcat Failure happens and Load Balancer cannot redirect the request to the
 
 Starting with v2.2, Hazelcast Tomcat Session Manager supports auto-configuration when used with Spring Boot. The only thing you need to do is to add Hazelcast Tomcat Session Manager (for Tomcat 9) and Hazelcast IMDG libraries to the classpath. This will set Hazelcast Session Manager as the session manager of the Tomcat. If you would like to configure the session manager properties, you can setup the following properties in your `application.properties` file:
 
+- `tsm.autoconfig.enabled`: Allows to enable/disable Spring Boot Auto-configuration for Hazelcast Tomcat Session Manager. Default is `true`, you need to set it to `false` if you would like to configure Hazelcast Tomcat Session Manager manually with Spring Boot.
 - `tsm.config.location`: Allows to provide Hazelcast member or client configuration. If not provided, `hazelcast.xml` in the classpath is used by default. 
 - `tsm.map.name`: Use this property if you have a specially configured map for special cases like WAN Replication, Eviction, MapStore, etc.
 - `tsm.sticky`: Allows to set sticky mode. Its default value is `true`.

--- a/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManagerConfiguration.java
+++ b/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManagerConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
 import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
@@ -37,6 +38,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 @Configuration
 @ConditionalOnClass(HazelcastSessionManager.class)
+@ConditionalOnProperty(name = "tsm.autoconfig.enabled", havingValue = "true", matchIfMissing = true)
 public class HazelcastSessionManagerConfiguration {
     private static final String TSM_HAZELCAST_CONFIG_LOCATION = "tsm.config.location";
     private final Log log = LogFactory.getLog(HazelcastSessionManager.class);


### PR DESCRIPTION
Some users might require to disable autoconfiguration if they configure Session Manager manually. This PR adds a new property to allow so.