### PR TITLE
Fixes new session creation on failover

### DIFF
--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionChangeValve.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionChangeValve.java
@@ -18,13 +18,21 @@ package com.hazelcast.session;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class HazelcastSessionChangeValve extends ValveBase {
 
+    private final Log log = LogFactory.getLog(HazelcastSessionChangeValve.class);
+
     private SessionManager sessionManager;
+
+    private Map<String, String> handledSessions = new HashMap<String, String>();
 
     public HazelcastSessionChangeValve(SessionManager sessionManager) {
         this.sessionManager = sessionManager;
@@ -52,8 +60,19 @@ public class HazelcastSessionChangeValve extends ValveBase {
             return;
         }
 
-        String newSessionId = sessionManager.updateJvmRouteForSession(currentSessionId, jvmRoute);
-        request.changeSessionId(newSessionId);
+        log.debug("Thread name: " + Thread.currentThread().getName() + ", Handling session id = " + currentSessionId);
+
+        String handledSessionId;
+        synchronized (this) {
+            if (!handledSessions.containsKey(currentSessionId)) {
+                handledSessions.put(currentSessionId, sessionManager.updateJvmRouteForSession(currentSessionId, jvmRoute));
+            }
+            handledSessionId = handledSessions.get(currentSessionId);
+        }
+
+        log.info("Thread name: " + Thread.currentThread().getName()
+                + ", Handled session id from " + currentSessionId + " to " + handledSessionId);
+        request.changeSessionId(handledSessionId);
         request.getSession().invalidate();
     }
 }

--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionChangeValve.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionChangeValve.java
@@ -60,8 +60,13 @@ public class HazelcastSessionChangeValve extends ValveBase {
             return;
         }
 
-        log.debug("Thread name: " + Thread.currentThread().getName() + ", Handling session id = " + currentSessionId);
+        request.changeSessionId(getOrCreateHandledSessionId(currentSessionId, jvmRoute));
+        request.getSession().invalidate();
+    }
 
+    private String getOrCreateHandledSessionId(String currentSessionId, String jvmRoute)
+            throws IOException {
+        log.debug(String.format("Thread name: %s, Handling session id: %s", Thread.currentThread().getName(), currentSessionId));
         String handledSessionId;
         synchronized (this) {
             if (!handledSessions.containsKey(currentSessionId)) {
@@ -70,9 +75,8 @@ public class HazelcastSessionChangeValve extends ValveBase {
             handledSessionId = handledSessions.get(currentSessionId);
         }
 
-        log.info("Thread name: " + Thread.currentThread().getName()
-                + ", Handled session id from " + currentSessionId + " to " + handledSessionId);
-        request.changeSessionId(handledSessionId);
-        request.getSession().invalidate();
+        log.info(String.format("Thread name: %s, Handled session id from %s to %s",
+                Thread.currentThread().getName(), currentSessionId, handledSessionId));
+        return handledSessionId;
     }
 }

--- a/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionChangeValve.java
+++ b/tomcat-core/src/main/java/com/hazelcast/session/HazelcastSessionChangeValve.java
@@ -72,8 +72,8 @@ public class HazelcastSessionChangeValve extends ValveBase {
             if (!handledSessions.containsKey(currentSessionId)) {
                 handledSessions.put(currentSessionId, sessionManager.updateJvmRouteForSession(currentSessionId, jvmRoute));
             }
-            handledSessionId = handledSessions.get(currentSessionId);
         }
+        handledSessionId = handledSessions.get(currentSessionId);
 
         log.info(String.format("Thread name: %s, Handled session id from %s to %s",
                 Thread.currentThread().getName(), currentSessionId, handledSessionId));

--- a/tomcat-core/src/test/java/com/hazelcast/session/sticky/AbstractStickySessionsTest.java
+++ b/tomcat-core/src/test/java/com/hazelcast/session/sticky/AbstractStickySessionsTest.java
@@ -174,10 +174,6 @@ public abstract class AbstractStickySessionsTest extends AbstractHazelcastSessio
         //given
         final CookieStore cookieStore = new BasicCookieStore();
         final CookieStore cookieStore2 = new BasicCookieStore();
-        String value = executeRequest("read", SERVER_PORT_1, cookieStore);
-        String value2 = executeRequest("read", SERVER_PORT_1, cookieStore2);
-        assertEquals("null", value);
-        assertEquals("null", value2);
         executeRequest("write", SERVER_PORT_1, cookieStore);
         executeRequest("write", SERVER_PORT_1, cookieStore2);
 
@@ -206,9 +202,9 @@ public abstract class AbstractStickySessionsTest extends AbstractHazelcastSessio
         }
 
         //then
-        value = executeRequest("read", SERVER_PORT_2, cookieStore);
+        String value = executeRequest("read", SERVER_PORT_2, cookieStore);
         assertEquals("value", value);
-        value2 = executeRequest("read", SERVER_PORT_2, cookieStore2);
+        String value2 = executeRequest("read", SERVER_PORT_2, cookieStore2);
         assertEquals("value", value2);
     }
 

--- a/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat6/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -271,7 +271,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             hazelcastSession.setDirty(false);
             sessionMap.set(session.getId(), hazelcastSession);
             if (log.isDebugEnabled()) {
-                log.debug("Thread name: " + Thread.currentThread().getName() + " committed key: " + session.getId());
+                log.debug(String.format("Thread name: %s committed key: %s", Thread.currentThread().getName(), session.getId()));
             }
         }
     }

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -254,21 +254,30 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
     @Override
     public String updateJvmRouteForSession(String sessionId, String newJvmRoute) {
-        HazelcastSession session = sessionMap.get(sessionId);
-        if (session == null) {
-            session = (HazelcastSession) createSession(null);
-            return session.getId();
-        }
+        HazelcastSession session;
+        String newSessionId;
+        sessionMap.lock(sessionId);
+        try {
+            session = sessionMap.get(sessionId);
+            if (session == null) {
+                session = (HazelcastSession) createSession(null);
+                log.debug("Thread name: " + Thread.currentThread().getName()
+                        + ", New session created when updating jvm route: " + session.getId());
+                return session.getId();
+            }
 
-        if (session.getManager() == null) {
-            session.setSessionManager(this);
-        }
-        int index = sessionId.indexOf(".");
-        String baseSessionId = sessionId.substring(0, index);
-        String newSessionId = baseSessionId + "." + newJvmRoute;
-        session.setId(newSessionId);
+            if (session.getManager() == null) {
+                session.setSessionManager(this);
+            }
+            int index = sessionId.indexOf(".");
+            String baseSessionId = sessionId.substring(0, index);
+            newSessionId = baseSessionId + "." + newJvmRoute;
+            session.setId(newSessionId);
 
-        sessionMap.remove(sessionId);
+            sessionMap.remove(sessionId);
+        } finally {
+            sessionMap.unlock(sessionId);
+        }
         sessionMap.set(newSessionId, session);
         return newSessionId;
     }

--- a/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat7/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -247,7 +247,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             hazelcastSession.setDirty(false);
             sessionMap.set(session.getId(), hazelcastSession);
             if (log.isDebugEnabled()) {
-                log.debug("Thread name: " + Thread.currentThread().getName() + " committed key: " + session.getId());
+                log.debug(String.format("Thread name: %s committed key: %s", Thread.currentThread().getName(), session.getId()));
             }
         }
     }
@@ -261,8 +261,8 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             session = sessionMap.get(sessionId);
             if (session == null) {
                 session = (HazelcastSession) createSession(null);
-                log.debug("Thread name: " + Thread.currentThread().getName()
-                        + ", New session created when updating jvm route: " + session.getId());
+                log.debug(String.format("Thread name: %s, New session created when updating jvm route: %s",
+                        Thread.currentThread().getName(), session.getId()));
                 return session.getId();
             }
 

--- a/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat8/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -248,7 +248,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             hazelcastSession.setDirty(false);
             sessionMap.set(session.getId(), hazelcastSession);
             if (log.isDebugEnabled()) {
-                log.debug("Thread name: " + Thread.currentThread().getName() + " committed key: " + session.getId());
+                log.debug(String.format("Thread name: %s committed key: %s", Thread.currentThread().getName(), session.getId()));
             }
         }
     }
@@ -262,8 +262,8 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             session = sessionMap.get(sessionId);
             if (session == null) {
                 session = (HazelcastSession) createSession(null);
-                log.debug("Thread name: " + Thread.currentThread().getName()
-                        + ", New session created when updating jvm route: " + session.getId());
+                log.debug(String.format("Thread name: %s, New session created when updating jvm route: %s",
+                        Thread.currentThread().getName(), session.getId()));
                 return session.getId();
             }
 

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -233,7 +233,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             hazelcastSession.setDirty(false);
             sessionMap.set(session.getId(), hazelcastSession);
             if (log.isDebugEnabled()) {
-                log.debug("Thread name: " + Thread.currentThread().getName() + " committed key: " + session.getId());
+                log.debug(String.format("Thread name: %s committed key: %s", Thread.currentThread().getName(), session.getId()));
             }
         }
     }
@@ -247,8 +247,8 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             session = sessionMap.get(sessionId);
             if (session == null) {
                 session = (HazelcastSession) createSession(null);
-                log.debug("Thread name: " + Thread.currentThread().getName()
-                        + ", New session created when updating jvm route: " + session.getId());
+                log.debug(String.format("Thread name: %s, New session created when updating jvm route: %s",
+                        Thread.currentThread().getName(), session.getId()));
                 return session.getId();
             }
 

--- a/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat85/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -240,21 +240,30 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
     @Override
     public String updateJvmRouteForSession(String sessionId, String newJvmRoute) {
-        HazelcastSession session = sessionMap.get(sessionId);
-        if (session == null) {
-            session = (HazelcastSession) createSession(null);
-            return session.getId();
-        }
+        HazelcastSession session;
+        String newSessionId;
+        sessionMap.lock(sessionId);
+        try {
+            session = sessionMap.get(sessionId);
+            if (session == null) {
+                session = (HazelcastSession) createSession(null);
+                log.debug("Thread name: " + Thread.currentThread().getName()
+                        + ", New session created when updating jvm route: " + session.getId());
+                return session.getId();
+            }
 
-        if (session.getManager() == null) {
-            session.setSessionManager(this);
-        }
-        int index = sessionId.indexOf(".");
-        String baseSessionId = sessionId.substring(0, index);
-        String newSessionId = baseSessionId + "." + newJvmRoute;
-        session.setId(newSessionId);
+            if (session.getManager() == null) {
+                session.setSessionManager(this);
+            }
+            int index = sessionId.indexOf(".");
+            String baseSessionId = sessionId.substring(0, index);
+            newSessionId = baseSessionId + "." + newJvmRoute;
+            session.setId(newSessionId);
 
-        sessionMap.remove(sessionId);
+            sessionMap.remove(sessionId);
+        } finally {
+            sessionMap.unlock(sessionId);
+        }
         sessionMap.set(newSessionId, session);
         return newSessionId;
     }

--- a/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -229,7 +229,7 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             hazelcastSession.setDirty(false);
             sessionMap.set(session.getId(), hazelcastSession);
             if (log.isDebugEnabled()) {
-                log.debug("Thread name: " + Thread.currentThread().getName() + " committed key: " + session.getId());
+                log.debug(String.format("Thread name: %s committed key: %s", Thread.currentThread().getName(), session.getId()));
             }
         }
     }
@@ -243,8 +243,8 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
             session = sessionMap.get(sessionId);
             if (session == null) {
                 session = (HazelcastSession) createSession(null);
-                log.debug("Thread name: " + Thread.currentThread().getName()
-                        + ", New session created when updating jvm route: " + session.getId());
+                log.debug(String.format("Thread name: %s, New session created when updating jvm route: %s",
+                        Thread.currentThread().getName(), session.getId()));
                 return session.getId();
             }
 

--- a/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
+++ b/tomcat9/src/main/java/com/hazelcast/session/HazelcastSessionManager.java
@@ -236,21 +236,30 @@ public class HazelcastSessionManager extends ManagerBase implements Lifecycle, P
 
     @Override
     public String updateJvmRouteForSession(String sessionId, String newJvmRoute) {
-        HazelcastSession session = sessionMap.get(sessionId);
-        if (session == null) {
-            session = (HazelcastSession) createSession(null);
-            return session.getId();
-        }
+        HazelcastSession session;
+        String newSessionId;
+        sessionMap.lock(sessionId);
+        try {
+            session = sessionMap.get(sessionId);
+            if (session == null) {
+                session = (HazelcastSession) createSession(null);
+                log.debug("Thread name: " + Thread.currentThread().getName()
+                        + ", New session created when updating jvm route: " + session.getId());
+                return session.getId();
+            }
 
-        if (session.getManager() == null) {
-            session.setSessionManager(this);
-        }
-        int index = sessionId.indexOf(".");
-        String baseSessionId = sessionId.substring(0, index);
-        String newSessionId = baseSessionId + "." + newJvmRoute;
-        session.setId(newSessionId);
+            if (session.getManager() == null) {
+                session.setSessionManager(this);
+            }
+            int index = sessionId.indexOf(".");
+            String baseSessionId = sessionId.substring(0, index);
+            newSessionId = baseSessionId + "." + newJvmRoute;
+            session.setId(newSessionId);
 
-        sessionMap.remove(sessionId);
+            sessionMap.remove(sessionId);
+        } finally {
+            sessionMap.unlock(sessionId);
+        }
         sessionMap.set(newSessionId, session);
         return newSessionId;
     }


### PR DESCRIPTION
When sticky sessions are enabled and failover happens, `HazelcastSessionChangeValve` was creating new sessions instead of using the existing one because of a concurrency issue. This was causing users to lose access to the current session.

This PR fixes the mentioned issue.